### PR TITLE
Link fixes, updated matlab code

### DIFF
--- a/appsFeatures/applications/bode/bode.rst
+++ b/appsFeatures/applications/bode/bode.rst
@@ -52,7 +52,7 @@ Main feature of the Bode analyzer application are described below:
     - excitation signal parameters (amplitude and DC bias) can be adjusted to make measurements in different 
       sensitivities and conditions (amplifiers etc.).
     - The calibration function enables calibrating long leads and to remove leads and cables effect on final 
-      measurements. The calibration will also calibrate your Red Pitaya if any parasitics effects are present.   
+      measurements. The calibration will also calibrate your Red Pitaya if any parasitics effects are present. Bode       calibration data is stored into **/tmp/ba_calib.data**.   
    
 .. figure:: BA_Slika_05.png
    

--- a/appsFeatures/applications/bode/bode.rst
+++ b/appsFeatures/applications/bode/bode.rst
@@ -52,7 +52,8 @@ Main feature of the Bode analyzer application are described below:
     - excitation signal parameters (amplitude and DC bias) can be adjusted to make measurements in different 
       sensitivities and conditions (amplifiers etc.).
     - The calibration function enables calibrating long leads and to remove leads and cables effect on final 
-      measurements. The calibration will also calibrate your Red Pitaya if any parasitics effects are present. Bode       calibration data is stored into **/tmp/ba_calib.data**.   
+      measurements. The calibration will also calibrate your Red Pitaya if any parasitics effects are present.
+      Bode calibration data is stored into **/tmp/ba_calib.data**.
    
 .. figure:: BA_Slika_05.png
    

--- a/appsFeatures/applications/bode/bode.rst
+++ b/appsFeatures/applications/bode/bode.rst
@@ -85,7 +85,7 @@ Specifications
 
 .. note::
 
-    Please take care that :ref:`position <anain>` are set to the correct input rage!
+    Please take care that :ref:`position <anain>` are set to the correct input range!
     
 
 HW connections

--- a/appsFeatures/remoteControl/jupyter/Jupyter.rst
+++ b/appsFeatures/remoteControl/jupyter/Jupyter.rst
@@ -181,40 +181,40 @@ Sensors
 ========================================================================================    ============
 Sensor information                                                                          Connector
 ========================================================================================    ============
-`Temperature sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Temperature_Sensor>`_         AI
-`Motion sensor <http://wiki.seeedstudio.com/wiki/Grove_-_PIR_Motion_Sensor>`_               DIO
-`Touch sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Touch_Sensor>`_                     DIO
-`Button <http://wiki.seeedstudio.com/wiki/Grove_-_Button>`_                                 DIO
-Switch
+`Temperature sensor <https://wiki.seeedstudio.com/Sensor_temperature>`_                     AI
+`Motion sensor <https://wiki.seeedstudio.com/Grove-PIR_Motion_Sensor>`_                     DIO
+`Touch sensor <https://wiki.seeedstudio.com/Grove-Touch_Sensor>`_                           DIO
+`Button <https://wiki.seeedstudio.com/Grove-Button>`_                                       DIO
+`Switch <https://wiki.seeedstudio.com/Grove-Switch-P>`_
 Digital
-`Tilt <http://wiki.seeedstudio.com/wiki/Grove_-_Tilt_Switch>`_                              DIO
-`Potentiometer <http://wiki.seeedstudio.com/wiki/Grove_-_Rotary_Angle_Sensor>`_             AI
-`Light sensor <http://wiki.seeed.cc/Grove-Light_Sensor/>`_                                  AI
-`Air quality sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Air_Quality_Sensor_v1.>`_     AI
-`Vibration sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Piezo_Vibration_Sensor>`_       AI
-`Moisture sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Moisture_Sensor>`_               AI
-`Water sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Water_Sensor>`_                     AI
-`Alcohol sensor <http://wiki.seeedstudio.com/wiki/Grove_-_Alcohol_Sensor>`_                 AI
+`Tilt <https://wiki.seeedstudio.com/Grove-Tilt_Switch>`_                                    DIO
+`Potentiometer <https://wiki.seeedstudio.com/Grove-Slide_Potentiometer>`_                   AI
+`Light sensor <http://wiki.seeed.cc/Grove-Light_Sensor>`_                                   AI
+`Air quality sensor <https://wiki.seeedstudio.com/Grove-Air_Quality_Sensor_v1.3>`_          AI
+`Vibration sensor <https://wiki.seeedstudio.com/Grove-Piezo_Vibration_Sensor>`_             AI
+`Moisture sensor <https://wiki.seeedstudio.com/Grove-Moisture_Sensor>`_                     AI
+`Water sensor <https://wiki.seeedstudio.com/Grove-Water_Sensor>`_                           AI
+`Alcohol sensor <https://wiki.seeedstudio.com/Grove-Alcohol_Sensor>`_                       AI
 Barometer ``not supported at the moment``                                                   I2C
 `Sound sensor <http://wiki.seeed.cc/Grove-Sound_Sensor/>`_                                  AI
-`UV sensor <http://wiki.seeedstudio.com/wiki/Grove_-_UV_Sensor>`_                           AI
+`UV sensor <https://wiki.seeedstudio.com/Grove-UV_Sensor>`_                                 AI
 Accelerometer ``not supported at the moment``                                               I2C
 ========================================================================================    ============
 
 ========================================================================================    ============
 Actuators                                                                                   Connector
 ========================================================================================    ============
-`Relay <http://wiki.seeedstudio.com/wiki/Grove_-_Relay>`_                                   DIO
+`Relay <https://wiki.seeedstudio.com/Grove-Relay>`_                                         DIO
 ========================================================================================    ============
 
 ========================================================================================    ============
 Indicators                                                                                  Connector
 ========================================================================================    ============
-`Buzzer <http://wiki.seeedstudio.com/wiki/Grove_-_Buzzer>`_                                 DIO
+`Buzzer <https://wiki.seeedstudio.com/Grove-Buzzer>`_                                       DIO
 `LED <https://www.seeedstudio.com/grove-led-p-767.html?cPath=156_157>`_                     DIO
 7 segment display                                                                           Digital pins
-LED bar                                                                                     Digital pins
-Groove LCD                                                                                  Digital pins
+`LED bar <https://wiki.seeedstudio.com/Grove-LED_Bar>`_                                     Digital pins
+`Groove LCD <https://wiki.seeedstudio.com/Grove-LCD_RGB_Backlight>`_                        Digital pins
 LCD                                                                                         Digital pins
 ========================================================================================    ============
 

--- a/developerGuide/software/build/comC.rst
+++ b/developerGuide/software/build/comC.rst
@@ -7,7 +7,7 @@ Compiling and running C applications
 You can write simple C algorithms, make executables and run them on the Red Pitaya board. A list of
 built in functions (APIs) is available providing full control over Red Pitaya board (signal generation and
 acquisition, digital I/O control, communication: I2C, SPI, UART and other).
-How to compile an C algorithm is shown in the instructions below, while a list of Examples is available
+How to compile a C algorithm is shown in the instructions below, while a list of Examples is available
 :ref:`here <list-of-supported-scpi-commands>`.
 
 Note: When you copy the source code from our repository (following instructions bellow) you will also
@@ -16,8 +16,7 @@ copy all C examples to your Red Pitaya board. After that only the compiling step
 
 **Compiling and running on Red Pitaya board**
 
-When compiling on the target no special preparations are needed. A native toolchain is available directly on the
-Debian system.
+When compiling on the target no special preparations are needed. A native toolchain is available directly on the Debian system.
 
 First connect to your board over :ref:`SSH <ssh>` (replace the IP, the default password is `root`).
 

--- a/quickStart/SDcard/SDcard.rst
+++ b/quickStart/SDcard/SDcard.rst
@@ -13,25 +13,38 @@ The next procedure will create a clean SD card.
 
 STEMlab 125-14 & STEMlab 125-10:
 
-   - `Latest Stable <https://downloads.redpitaya.com/downloads/STEMlab-125-1x/STEMlab_125-xx_OS_1.04-9_stable.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG.md>`_
-   - `Latest Beta <https://downloads.redpitaya.com/downloads/STEMlab-125-1x/STEMlab_125-xx_OS_1.04-11_beta.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG.md>`_
+   - `Latest Stable <https://downloads.redpitaya.com/downloads/STEMlab-125-1x/STEMlab_125-xx_OS_1.04-9_stable.img.zip>`_  - |CHANGELOG|
+   - `Latest Beta <https://downloads.redpitaya.com/downloads/STEMlab-125-1x/STEMlab_125-xx_OS_1.04-11_beta.img.zip>`_  - |CHANGELOG|
 
 STEMlab 125-14-Z7020:
 
-   - `Latest Stable <https://downloads.redpitaya.com/downloads/STEMlab-125-14-Z7020/STEMlab_125-14-Z7020_OS_1.04-7_stable.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG.md>`_
-   - `Latest Beta <https://downloads.redpitaya.com/downloads/STEMlab-125-14-Z7020/STEMlab_125-14-Z7020_OS_1.04-10_beta.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG.md>`_
+   - `Latest Stable <https://downloads.redpitaya.com/downloads/STEMlab-125-14-Z7020/STEMlab_125-14-Z7020_OS_1.04-7_stable.img.zip>`_  - |CHANGELOG|
+   - `Latest Beta <https://downloads.redpitaya.com/downloads/STEMlab-125-14-Z7020/STEMlab_125-14-Z7020_OS_1.04-10_beta.img.zip>`_  - |CHANGELOG|
 
 SDRlab 122-16:
 
-   - `Latest Stable <https://downloads.redpitaya.com/downloads/SDRlab-122-16/SDRlab_122-16_OS_1.04-9_stable.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG_Z20.md>`_
-   - `Latest Beta <https://downloads.redpitaya.com/downloads/SDRlab-122-16/SDRlab_122-16_OS_1.04-11_beta.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG_Z20.md>`_
+   - `Latest Stable <https://downloads.redpitaya.com/downloads/SDRlab-122-16/SDRlab_122-16_OS_1.04-9_stable.img.zip>`_  - |CHANGELOG_Z20|
+   - `Latest Beta <https://downloads.redpitaya.com/downloads/SDRlab-122-16/SDRlab_122-16_OS_1.04-11_beta.img.zip>`_  - |CHANGELOG_Z20|
 
 SIGNALlab 250-12:
 
-   - `Latest Stable <https://downloads.redpitaya.com/downloads/SIGNALlab-250-12/SIGNALlab_250-12_OS_1.04-24_stable.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG_Z20_250_12.md>`_
-   - `Latest Beta <https://downloads.redpitaya.com/downloads/SIGNALlab-250-12/SIGNALlab_250-12_OS_1.04-27_beta.img.zip>`_  - `CHANGELOG <https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG_Z20_250_12.md>`_
+   - `Latest Stable <https://downloads.redpitaya.com/downloads/SIGNALlab-250-12/SIGNALlab_250-12_OS_1.04-24_stable.img.zip>`_  - |CHANGELOG_Z20_250_12|
+   - `Latest Beta <https://downloads.redpitaya.com/downloads/SIGNALlab-250-12/SIGNALlab_250-12_OS_1.04-27_beta.img.zip>`_  - |CHANGELOG_Z20_250_12|
 
 
+.. |CHANGELOG| raw:: html
+
+   <a href="https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG.md" target="_blank">CHANGELOG</a>
+
+.. |CHANGELOG_Z20| raw:: html
+
+   <a href="https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG_Z20.md" target="_blank">CHANGELOG</a>
+
+.. |CHANGELOG_Z20_250_12| raw:: html
+
+   <a href="https://github.com/RedPitaya/RedPitaya/blob/master/CHANGELOG_Z20_250_12.md" target="_blank">CHANGELOG</a>
+   
+   
 
 .. figure:: microSDcard-RP.png
     :width: 10%


### PR DESCRIPTION
Change log links should now open in a new tab automatically, updated one MATLAB example to new syntax (the current syntax will not work in future updates of MATLAB) (old syntax still works as of MATLAB R2021b v3). All have to do with the accidental merge of my master branch cca 4 days ago. 

I tested changelog in read the docs (seperate branch)