### PR TITLE
Fix sphinx-build warnings, spelling

### DIFF
--- a/appsFeatures/applications/sdr/appSDR.rst
+++ b/appsFeatures/applications/sdr/appSDR.rst
@@ -1,14 +1,14 @@
 SDR
 ###
 
-What is in the box 
+What is in the box
 ******************
 
 The following accessories and materials are included with your Red Pitaya SDR transceiver module.
 
 	* SDR transceiver 160-10 10W module
 	* DC power cord with Anderson Power Pole™ connector
-	* 4 x SMA cable for connecting C25 module with STEMlab 125-14 and antenna   
+	* 4 x SMA cable for connecting C25 module with STEMlab 125-14 and antenna
 	* impedance transformer board
 
 .. _Hercules: https://www.hercules.com/uk/leisure-controllers/bdd/p/248/djcontrol-instinct-s-series/
@@ -20,15 +20,15 @@ Other additional requirements
 In addition to the supplied accessories, software and cables supplied with Red Pitaya SDR transceiver kit, you will need to provide the following:
 
 	* An **HF-Antenna** or dummy load with BNC
-	* good RF **ground**	
+	* good RF **ground**
 	* A stabilized DC 13.8 VDC, 3A **Power Supply**
 
 SDR application requirements:
 
-	* Personal computer (PC) running Windows 7 or later. Either 32 or 64-bit operating systems are supported. 
+	* Personal computer (PC) running Windows 7 or later. Either 32 or 64-bit operating systems are supported.
 
 Start using Red Pitaya as Radio Station - SDR transceiver
-********************************************************
+*********************************************************
 
 Connecting the cables
 ---------------------
@@ -36,11 +36,11 @@ Connecting the cables
 .. image :: 16_RedPitaya_Combo2.jpg
    :alt: icon
    :align: center
-   
+
 .. note::
-	
+
 	Before connecting Red Pitaya to SDR transceiver module, turn Red Pitaya off, by removing power supply cable.
-	
+
 
 1. connect Tx of SDR transciver module to Red Pitaya OUT1
 2. connect Rx of SDR ransciver module to Red Pitaya IN1 (notice this cable has a transformer)
@@ -51,7 +51,7 @@ identify pin with arrow and connect the cable as on the image bellow.
 .. image :: 18_RedPitaya_Close.jpg
    :alt: icon
    :align: center
-   
+
 4. Make sure jumper is set as shown on image above.
 5. Make sure your SD card is still inserted
 6. Make sure your ethernet cable is still plugged in
@@ -60,13 +60,13 @@ identify pin with arrow and connect the cable as on the image bellow.
 9. Connect SDR transceiver to 13.8V 3A power supply
 
 .. note::
-	
-	Red Pitaya SDR transceiver module should be powered by DC 13.8V Power Supply that can provide at least 3 A of constant power. 
-	Make sure that is turned off and then use DC power cord with Anderson Power Pole™ connector **(9)** to connect it with module. 
-	RED wire is positive (+) while BLACK wire is negative (-), double check to not mix the colours or polarity! 
 
-	
-10. Turn on 13.8V power supply	
+	Red Pitaya SDR transceiver module should be powered by DC 13.8V Power Supply that can provide at least 3 A of constant power.
+	Make sure that is turned off and then use DC power cord with Anderson Power Pole™ connector **(9)** to connect it with module.
+	RED wire is positive (+) while BLACK wire is negative (-), double check to not mix the colours or polarity!
+
+
+10. Turn on 13.8V power supply
 
 
 Power SDR installation and SDR configuration
@@ -81,22 +81,22 @@ Click here_ to download Power SDR installation package.
 	.. image :: PowerSDRinstallation1.PNG
 		:align: center
 
-2. If you are asked for extended user access rights during the installation click Yes! Running installer with administration rights will work as well. 
-	
+2. If you are asked for extended user access rights during the installation click Yes! Running installer with administration rights will work as well.
+
 	.. image :: PowerSDRinstallation2.png
 		:scale: 70%
    		:align: center
-		
+
 On Windows 10 you might get warning of Unknown Publisher you can procede with installation by clicking on "more info" and then "Run anyway".
- 
+
 	.. figure:: PowerSDRinstallation3.PNG
 		:scale: 75 %
    		:align: center
-	
+
 	.. figure:: PowerSDRinstallation4.PNG
 		:scale: 75 %
    		:align: center
-	
+
 
 3. Follow the instructions of the setup routine and accept the license agreements if asked for.
 
@@ -107,7 +107,7 @@ On Windows 10 you might get warning of Unknown Publisher you can procede with in
 	.. figure:: Capture2.PNG
 		:scale: 75 %
    		:align: center
-		
+
 	.. figure:: Capture3.PNG
 		:scale: 75 %
    		:align: center
@@ -201,11 +201,11 @@ General Specifications
 
 .. Measurement instruments specifications
 .. ######################################
-.. 
-.. 
+..
+..
 .. Oscilloscope
 .. ************
-.. 
+..
 .. +-------------------------------+-----------------------+
 .. | Input channels		| 2			|
 .. +-------------------------------+-----------------------+
@@ -229,12 +229,12 @@ General Specifications
 .. +-------------------------------+-----------------------+
 .. | Input coupling		| AC/DC 		|
 .. +-------------------------------+-----------------------+
-.. 
-.. 
-.. 
+..
+..
+..
 .. Signal generator
 .. ****************
-.. 
+..
 .. +---------------------------------------+-----------------------+
 .. | Output channels			| 2			|
 .. +---------------------------------------+-----------------------+
@@ -256,12 +256,12 @@ General Specifications
 .. +---------------------------------------+-----------------------+
 .. | External Trigger connector		| BNC			|
 .. +---------------------------------------+-----------------------+
-.. 
-.. 
-.. 
+..
+..
+..
 .. Spectrum analyzer
 .. *****************
-.. 
+..
 .. +-------------------------------+--------------------+
 .. | Input channels		|	2	     |
 .. +-------------------------------+--------------------+
@@ -281,15 +281,15 @@ General Specifications
 .. +-------------------------------+--------------------+
 .. | Spurious frequency components	| -90 dBFS Typically |
 .. +-------------------------------+--------------------+
-.. 
-.. 
+..
+..
 .. Logic analyzer
 .. **************
-.. 
+..
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
 .. | Input channels				| 8                                                                                             |
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
-.. | Max. sample rate				| 125 MS/s											|	
+.. | Max. sample rate				| 125 MS/s											|
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
 .. | Fastest input signal				| 50 MHz											|
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
@@ -305,32 +305,32 @@ General Specifications
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
 .. | Sample depth					| 1 MS (typical*)										|
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
-.. | Trigger resolution				| 8 ns												|				
+.. | Trigger resolution				| 8 ns												|
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
 .. | Min. detectable pulse length			| 10 ns												|
 .. +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
-.. 																			
-.. 
+..
+..
 .. .. note::
-.. 
-.. 	Acquired data is compressed therefore the size of data than can be captured depends on activity of signal on LA inputs. 
-.. 	For I2C, SPI & UART signals 1MS is typical sample depth.											
-.. 	All instrumentation applications are WEB based and don’t require the installation of any native software.					
-.. 	Users can access them via a browser using their smartphone, tablet or a PC running any popular operating systems (MAC, Linux, Windows, Android and iOS).	
-.. 
-.. 
+..
+.. 	Acquired data is compressed therefore the size of data than can be captured depends on activity of signal on LA inputs.
+.. 	For I2C, SPI & UART signals 1MS is typical sample depth.
+.. 	All instrumentation applications are WEB based and don’t require the installation of any native software.
+.. 	Users can access them via a browser using their smartphone, tablet or a PC running any popular operating systems (MAC, Linux, Windows, Android and iOS).
+..
+..
 .. General Electrical specifications
 .. #################################
-.. 
+..
 .. +-----------------------+-----------------------------------------------------------------------+
 .. | Power Requirements:	| +13.8 V DC nominal ± 15 % (Transmitter output specified at 13.8 V DC)	|
 .. +-----------------------+-----------------------------------------------------------------------+
 .. | Power Consumption:	| 2 A                                                                   |
 .. +-----------------------+-----------------------------------------------------------------------+
-.. 
+..
 .. Mechanical specifications
 .. #########################
-.. 
+..
 .. +---------------------------+----------------+
 .. | Height:                   |  100 mm        |
 .. +---------------------------+----------------+
@@ -345,34 +345,34 @@ General Specifications
 
 .. .. _front:
 
-.. Front panel controls and connections 
+.. Front panel controls and connections
 .. ####################################
-.. 
-.. 
+..
+..
 .. .. figure:: Front_panel_controls_and_connections.png
-.. 
+..
 .. Power button
-.. ************ 
-.. 
+.. ************
+..
 .. Momentarily pressing power button **(1)** will turn the HAMlab ON. It normally takes 30s from the button press until the HAMlab is ready to be used. Once HAMlab is ON, holding the power button pressed will cause the proper shut down of the device. Blue LED indication on the power button indicates that device is turned on.
-.. 
+..
 .. .. note::
-.. 	In case that system halts and becomes unresponsive, device can be turned off by holding power button for a few seconds / until the blue LED is turned off. 
+.. 	In case that system halts and becomes unresponsive, device can be turned off by holding power button for a few seconds / until the blue LED is turned off.
 
 
 .. SDR
 .. ***
-.. 
+..
 .. Microphone connector (RJ45)
 .. ---------------------------
-.. 
+..
 .. The HAMlab 80-10 10W front microphone connector **(2)** can support Kenwood KMC 30 electret microphone
 .. or compatible types.
-.. 
+..
 .. .. figure:: microfono-kmc-30-ml.jpg
-.. 
+..
 .. Front panel view microphone pinout
-.. 
+..
 .. +-----+----------+
 .. + Pin | Function +
 .. +=====+==========+
@@ -392,233 +392,233 @@ General Specifications
 .. +-----+----------+
 .. | 8   | NC	 |
 .. +-----+----------+
-.. 
+..
 .. CW Key / paddle jack
 .. --------------------
-.. 
-.. The CW key/paddle jack **(3)** is a ¼ inch TRS phone plug. 
+..
+.. The CW key/paddle jack **(3)** is a ¼ inch TRS phone plug.
 .. Tip - DOT
 .. Ring - DASH
-.. The common is connected to the sleeve. 
-.. 
-.. 
+.. The common is connected to the sleeve.
+..
+..
 .. .. note::
 .. 	3.3V Max input.
-.. 
-.. 
-.. For an iambic paddle, the tip is connected to the dot paddle, the ring is connected to the dash paddle and the sleeve is connected to the common. For a straight key or a keyer output, connect to the tip and leave the ring floating. The common is connected to the sleeve. 
-.. 
+..
+..
+.. For an iambic paddle, the tip is connected to the dot paddle, the ring is connected to the dash paddle and the sleeve is connected to the common. For a straight key or a keyer output, connect to the tip and leave the ring floating. The common is connected to the sleeve.
+..
 .. .. note::
-.. 
-.. 	Currently keyer is not supported by software. Software support for it will be availabe in one of incomming software updates. 
-.. 
-.. 
+..
+.. 	Currently keyer is not supported by software. Software support for it will be availabe in one of incomming software updates.
+..
+..
 .. Phones
 .. ------
-.. 
+..
 .. The HAMlab 80-10 10W supports a stereo headset with headphone ¼ inch TRS phone plug **(4)** .
 .. Mono or TS connector that grounds the “ring” portion of the connector should not be used!
-.. 
-.. 
-.. 
+..
+..
+..
 .. Logic analyzer
 .. --------------
-.. 
-.. 0-7 are logic analyzer inputs. 
-.. G - common ground. 
-.. 
-.. 
+..
+.. 0-7 are logic analyzer inputs.
+.. G - common ground.
+..
+..
 .. .. note::
-.. 	
+..
 .. 	Logic analyzer inputs **(5)** can only be used when running Logic analyzer WEB app.
-.. 
-.. 
-.. 
+..
+..
+..
 .. Oscilloscope
 .. ------------
-.. 
+..
 .. 	**(6)** - IN1
 .. 	**(7)** - IN2
 .. 	**(8)** - EXT. TRIG.
-.. 
-.. IN1, IN2 and EXT. TRIG. are oscilloscope inputs. 
-.. 
+..
+.. IN1, IN2 and EXT. TRIG. are oscilloscope inputs.
+..
 .. .. note::
-.. 
-.. 	These inputs are active and can be used only when Oscilloscope+Signal generator WEB application is running. 
-.. 
-.. 
+..
+.. 	These inputs are active and can be used only when Oscilloscope+Signal generator WEB application is running.
+..
+..
 .. Signal generator
 .. ----------------
-.. 
+..
 .. 	**(9)** - OUT1
 .. 	**(10)** - OUT2
-.. 
-.. OUT1 and OUT2 are signal generator outputs. 
-.. 
+..
+.. OUT1 and OUT2 are signal generator outputs.
+..
 .. .. note::
-.. 
+..
 .. 	These two outputs are active and can be controlled only when Oscilloscope+Signal generator WEB application is running.
-.. 
-.. 
+..
+..
 .. .. note::
-.. 
+..
 .. 	To get expected signals from the signal generator, outputs must be 50ohm terminated.
-.. 
-.. 
-.. 
-.. 
+..
+..
+..
+..
 .. .. _back:
-.. 
-.. Back panel controls and connections 
+..
+.. Back panel controls and connections
 .. ###################################
-.. 
-.. 
+..
+..
 .. .. figure:: Back_panel_controls_and_connections.png
-.. 
-.. 
+..
+..
 .. ANT - TRANSCEIVER ANTENNA PORTS [1,2]
-.. ************************************* 
-.. 
-.. ANT1 **(1)** is SO-239 50 ohm connector, while ANT2 **(2)** is BNC 50 ohm connector. 
-.. 
-.. 
+.. *************************************
+..
+.. ANT1 **(1)** is SO-239 50 ohm connector, while ANT2 **(2)** is BNC 50 ohm connector.
+..
+..
 .. User can connect transmitter output to ANT1 or ANT2 by properly connecting SMA cable inside the chassis to one of ANT connectors. Software switching between ANT1 and ANT2 is not available in HAMlab 80-10 10W version.
-.. 
+..
 .. .. danger::
-.. 
-.. 	THIS UNIT GENERATES RADIO FREQUENCY (RF) ENERGY. USE CAUTION AND OBSERVE PROPER SAFETY PRACTICES REGARDING YOUR SYSTEM CONFIGURATION. WHEN ATTACHED TO AN ANTENNA, THIS RADIO IS CAPABLE OF GENERATING RF ELECTROMAGNETIC FIELDS WHICH REQUIRE EVALUATION ACCORDING TO YOUR NATIONAL LAW TO PROVIDE ANY NECESSARY ISOLATION OR PROTECTION REQUIRED, WITH RESPECT TO HUMAN EXPOSURE! 
-.. 
+..
+.. 	THIS UNIT GENERATES RADIO FREQUENCY (RF) ENERGY. USE CAUTION AND OBSERVE PROPER SAFETY PRACTICES REGARDING YOUR SYSTEM CONFIGURATION. WHEN ATTACHED TO AN ANTENNA, THIS RADIO IS CAPABLE OF GENERATING RF ELECTROMAGNETIC FIELDS WHICH REQUIRE EVALUATION ACCORDING TO YOUR NATIONAL LAW TO PROVIDE ANY NECESSARY ISOLATION OR PROTECTION REQUIRED, WITH RESPECT TO HUMAN EXPOSURE!
+..
 .. .. danger::
-.. 
-.. 	NEVER CONNECT OR DISCONNECT ANTENNAS WHILE IN TRANSMIT MODE. THIS MAY CAUSE ELECTRICAL SHOCK OR RF BURNS TO YOUR SKIN AND DAMAGE TO THE UNIT. 
-.. 
-.. 
+..
+.. 	NEVER CONNECT OR DISCONNECT ANTENNAS WHILE IN TRANSMIT MODE. THIS MAY CAUSE ELECTRICAL SHOCK OR RF BURNS TO YOUR SKIN AND DAMAGE TO THE UNIT.
+..
+..
 .. AUX1
 .. ****
-.. 
+..
 .. RX1 IN - direct feed to the first receiver pre-amp and attenuators.
-.. 
-.. RX1 OUT - an output from the antenna feeding 
-.. 
-.. 
+..
+.. RX1 OUT - an output from the antenna feeding
+..
+..
 .. By default HAMlab 80-10 10W comes with loopback cable connected from RX1 IN to RX1 OUT. User can also use this two connectors to insert external filters or preamplifier.
-.. 
-.. 
+..
+..
 .. .. note::
-.. 	This input is not protected by any ESD circuitry, therefore device connected to the RX1 OUT Output is susceptible to possible damage by ESD from an EMP event if the connected device does not have adequate ESD protection circuitry. 
-.. 
+.. 	This input is not protected by any ESD circuitry, therefore device connected to the RX1 OUT Output is susceptible to possible damage by ESD from an EMP event if the connected device does not have adequate ESD protection circuitry.
+..
 .. .. warning::
-.. 	Be aware that Preamp1 and Preamp 2 are both wide band amplifiers covering the whole bandwidth of 55MHz. 
+.. 	Be aware that Preamp1 and Preamp 2 are both wide band amplifiers covering the whole bandwidth of 55MHz.
 .. 	It is not recommended to use the Preamps on a large Antenna without a Preselector connected (this would cause overload and intermodulation from strong broadcast signals outside the Amateur Radio Bands)!
-.. 
+..
 .. AUX2
 .. ****
-.. 
+..
 .. RX2 IN - secondary 50ohm receiver input that can be used as a second panadapter in Power SDR software
-.. or to as feedback signal for pre-distortions (Pure Signal tool). 
-.. 
-.. 
+.. or to as feedback signal for pre-distortions (Pure Signal tool).
+..
+..
 .. XVTR (TX2 OUT)  - secondary transmitter can be used to drive external PA
 .. Max. output power is around 10 dBm @ 50ohm.
-.. 
+..
 .. However, currently there is no support in HPSDR for a second TX output.
-.. 
+..
 .. Power and Fuses
 .. ***************
-.. 
+..
 .. The HAMlab 80-10 10W  is designed to operate from a 13.8 volt nominal DC supply and required at least 4A.
-.. 
+..
 .. .. danger::
-.. 
-..     This unit must only be operated with the electrical power described in this manual. NEVER CONNECT THE +13.8VDC POWER CONNECTOR DIRECTLY TO AN AC OUTLET. This may cause a fire, injury, or electrical shock. 
-.. 
-.. 
-.. The HAMlab 80-10 10W requires 13.8 VDC @ 4 A measured at the radio in order to transmit maximum wattage. Multiple power cable connections between the power supply and the HAMlab 80-10 10W, a poorly regulated power supply, undersized power cable and very long power cable lengths will result in a voltage drop, especially under load. Any voltage deviation from 13.8 VDC will result in lower power output that the 10W nominal specification. 
-.. 
-.. 
-.. For best results, select a linear or switching power supply that is well regulated and free of internally generated radio frequency noise. “Birdies” generated by a poorly filtered supply can often appear as signals in the Power SDR Panadapter display. 
-.. 
-.. 
-.. The Anderson Powerpole™ connector contains 45 Amp pins to minimize voltage drop during transmit. The RED connection should be connected to the positive (+) lead of the power source. The BLACK connection should be connected to the negative (-) lead of the power source. 
-.. 
-.. 
-.. I - If you choose to use your own Powerpole cabling, be sure to properly size the wire and the Powerpole connector to minimize voltage drop during transmit. Excessive voltage drop can cause lower transmit power output levels. 
-.. 
-.. 
-.. There are two internal fuses in the HAMlab. One is protecting whole system while the other one is just for the transceiver. If you ever need to replace the internal fuse, remove the top cover and the shield of the power board.  
-.. 
-.. 
+..
+..     This unit must only be operated with the electrical power described in this manual. NEVER CONNECT THE +13.8VDC POWER CONNECTOR DIRECTLY TO AN AC OUTLET. This may cause a fire, injury, or electrical shock.
+..
+..
+.. The HAMlab 80-10 10W requires 13.8 VDC @ 4 A measured at the radio in order to transmit maximum wattage. Multiple power cable connections between the power supply and the HAMlab 80-10 10W, a poorly regulated power supply, undersized power cable and very long power cable lengths will result in a voltage drop, especially under load. Any voltage deviation from 13.8 VDC will result in lower power output that the 10W nominal specification.
+..
+..
+.. For best results, select a linear or switching power supply that is well regulated and free of internally generated radio frequency noise. “Birdies” generated by a poorly filtered supply can often appear as signals in the Power SDR Panadapter display.
+..
+..
+.. The Anderson Powerpole™ connector contains 45 Amp pins to minimize voltage drop during transmit. The RED connection should be connected to the positive (+) lead of the power source. The BLACK connection should be connected to the negative (-) lead of the power source.
+..
+..
+.. I - If you choose to use your own Powerpole cabling, be sure to properly size the wire and the Powerpole connector to minimize voltage drop during transmit. Excessive voltage drop can cause lower transmit power output levels.
+..
+..
+.. There are two internal fuses in the HAMlab. One is protecting whole system while the other one is just for the transceiver. If you ever need to replace the internal fuse, remove the top cover and the shield of the power board.
+..
+..
 .. .. figure:: IMG_20161202_105403.jpg
-.. 
+..
 .. .. figure:: IMG_20161202_105424.jpg
-.. 
+..
 .. .. danger::
-.. 
-.. 	FUSE CURRENT RATING SHOULD NOT BE HIGHER THAN 3.15A AMPS! FAILURE TO PROPERLY USE THIS SAFETY DEVICE COULD RESULT IN DAMAGE TO YOUR RADIO, POWER SUPPLY, OR CREATE A FIRE RISK. 
-.. 
-.. 
+..
+.. 	FUSE CURRENT RATING SHOULD NOT BE HIGHER THAN 3.15A AMPS! FAILURE TO PROPERLY USE THIS SAFETY DEVICE COULD RESULT IN DAMAGE TO YOUR RADIO, POWER SUPPLY, OR CREATE A FIRE RISK.
+..
+..
 .. Chassis ground
 .. **************
-.. 
+..
 .. This is a thumbscrew for attaching an earth ground to the chassis of the radio. Grounding is the most important safety enhancement you can make to your shack. Always ground the HAMlab to your station RF ground using high quality wiring with the length being as short as possible.
-.. Braided wire is considered the best for ground applications. Your station ground should be a common point where all grounds come together. You will likely be using a PC and a DC power source so be sure to ground these devices together as well. 
-.. 
-.. 
+.. Braided wire is considered the best for ground applications. Your station ground should be a common point where all grounds come together. You will likely be using a PC and a DC power source so be sure to ground these devices together as well.
+..
+..
 .. AUDIO
 .. *****
-.. 
+..
 .. Audio USB connector
 .. USB 2.0 Cable - A-Male to Mini-B must be used to connect HAMlab audio sound card with the PC in order to be able to use Phone, MIC and speaker connector for voice communication.
-.. 
+..
 .. .. note::
 .. 	USB connector is only available on HAMlab 80-10 10W model. For new models audio codec is used / audio is transferred over ethernet.
-.. 
-.. Speaker connector 
+..
+.. Speaker connector
 .. 1/8” TRS stereo connector can be used to connect stereo powered computer speakers.
-.. 
+..
 .. .. note::
-..     Do not use a mono or TS connector that grounds the “ring” portion of the connector. 
-.. 
-.. 
+..     Do not use a mono or TS connector that grounds the “ring” portion of the connector.
+..
+..
 .. CTRL
 .. ****
-.. 
+..
 .. DB9 connector is used to control external equipment.
-.. PTT OUT relay is connected between pins 6 and 7. 
-.. 
+.. PTT OUT relay is connected between pins 6 and 7.
+..
 .. .. note::
-.. 
+..
 .. 	Other pins are at the moment not in use and should be left unconnected.
-.. 
-.. 
+..
+..
 .. DATA
 .. ****
-.. 
-.. LAN 
+..
+.. LAN
 .. This is network connection to the HAMlab. It is an auto-sensing 100 megabit or 1 gigabit Ethernet port that enables you to connect HAMlab to your local network or directly to PC.
-.. 
-.. 
+..
+..
 .. USB
 .. This USB port is used to connect WIFI dongle when user would like to connect to HAMlab wirelessly.
-.. 
+..
 .. .. note::
-.. 
+..
 .. 	Recommended WIFI USB dongle is Edimax EW7811Un. In general all WIFI USB dongles that use RTL8188CUS chipset should work.
-.. 
-.. 
-.. SD card 
-.. HAMlab software is running from SD card. 
-.. 
-.. .. note:: 
-.. 	
+..
+..
+.. SD card
+.. HAMlab software is running from SD card.
+..
+.. .. note::
+..
 .. 	HAMlab comes with pre installed SD card HAMlab OS. Upgrade can be done using OS upgrade application from the HAMlab application menu and there is no need to remove the SD card. Therefore user should remove the SD card and reinstall SD card software only if system gets corrupted or stops working due to SD card failure reason. In this case only official HAMlab OS should be installed on the SD card for proper operation.
 
-	
+
 
 .. Highlights
 .. **********
-.. 
+..
 .. +-------------------------------+-------------------------------------------------------------------------------------------------------------+
 .. | Architecture:                 | direct sampling / internal high performance 14-bit A/D and D/A 125 Msps converters (no sound card required) |
 .. +-------------------------------+-------------------------------------------------------------------------------------------------------------+
@@ -638,7 +638,7 @@ General Specifications
 .. +-------------------------------+-------------------------------------------------------------------------------------------------------------+
 .. | CW key and paddle input:      | available through front panel jack connector                                                                |
 .. +-------------------------------+-------------------------------------------------------------------------------------------------------------+
-.. 
+..
 
 .. figure:: SDRBlockDiagram.PNG
         :scale: 75 %
@@ -652,7 +652,7 @@ Receiver Specifications
 +-------------------------------+-------------------------------------------------+
 | ADC Sampling Rate:            | 125Msps                                         |
 +-------------------------------+-------------------------------------------------+
-| ADC Resolution:               | 14 bits                                         | 
+| ADC Resolution:               | 14 bits                                         |
 +-------------------------------+-------------------------------------------------+
 | Wideband Frequency Coverage:  | 25 kHz - 62.25 MHz                              |
 +-------------------------------+-------------------------------------------------+
@@ -668,10 +668,10 @@ Receiver Specifications
 +-------------------------------+-------------------------------------------------+
 | Preselectors:                 | Available as add-on module (comming soon)       |
 +-------------------------------+-------------------------------------------------+
-|                               | User can also connect own preselectors/filters  |   
+|                               | User can also connect own preselectors/filters  |
 +-------------------------------+-------------------------------------------------+
 
-Transmitter Specifications		
+Transmitter Specifications
 **************************
 
 +-------------------------------+--------------------------------------------------------------------------------------+
@@ -691,7 +691,7 @@ Transmitter Specifications
 +-------------------------------+--------------------------------------------------------------------------------------+
 | Emission Modes Types:         | A1A (CWU, CWL), J3E (USB, LSB), A3E (AM), F3E (FM), DIGITAL (DIGU, DIGL)             |
 +-------------------------------+--------------------------------------------------------------------------------------+
-|                               | DIGITAL (DIGU, DIGL)                                                                 | 
+|                               | DIGITAL (DIGU, DIGL)                                                                 |
 +-------------------------------+--------------------------------------------------------------------------------------+
 | Harmonic Radiation:           | better than -45 dB                                                                   |
 +-------------------------------+--------------------------------------------------------------------------------------+

--- a/appsFeatures/applications/streaming/appXCStreaming.rst
+++ b/appsFeatures/applications/streaming/appXCStreaming.rst
@@ -14,11 +14,11 @@ Overview:
 
 X-Channel streaming is suitable for applications that require multiple acquisition or generation channels.
 
-Red Pitaya X-Channel streaming software provides ability of streaming analog and digital signals to client PCs from 
+Red Pitaya X-Channel streaming software provides ability of streaming analog and digital signals to client PCs from
 several Red Pitaya devices simultaneously, with synchronized clock and trigger among all Red Pitayas in the system.
 
-Streaming can be done in both directions. Users can stream acquired analog and digital signals from Red Pitaya devices 
-to client computer or streame analog and digital signals from the client to Red Pitaya devices outputs. X-Channel 
+Streaming can be done in both directions. Users can stream acquired analog and digital signals from Red Pitaya devices
+to client computer or stream analog and digital signals from the client to Red Pitaya devices outputs. X-Channel
 streaming software also provides the ability to control streaming completely remotely from client PCs.
 
 .. figure:: img/RPs_to_PC_conn.png
@@ -29,20 +29,20 @@ Setup preparation:
 ***********************
 
 What do I need before I start?
-Red Pitaya STEMlab 125-14 X-channel system that consists of multiple STEMlab 125-14 LN devices that are modified for 
-clock and trigger synchronization, and also comes with SATA synchronization cables and software thatsupports X-Channel 
+Red Pitaya STEMlab 125-14 X-channel system that consists of multiple STEMlab 125-14 LN devices that are modified for
+clock and trigger synchronization, and also comes with SATA synchronization cables and software that supports X-Channel
 RF signal acquisition and generation.
 
 .. figure:: img/Master_and_slaves.jpg
     :width: 80%
 
-Notice that in Red Pitaya STEMlab 125-14 X-channel system inludes two types of devices:
+Notice that in Red Pitaya STEMlab 125-14 X-channel system includes two types of devices:
 
     * one STEMlab 125-14 MASTER device (which is standard STEMlab 125-14 device)
     * one or more STEMlab 125-14 SLAVE devices that are marked with “S” sticker
 
-In order to achieve synchronization, the MASTER device provides a clock and trigger over the SATA S1 connector that 
-is then connected to the S2 of SLAVE 1 board. SLAVE1 then passes the clock forward to SLAVE 2, SLAVE2 to SLAVE 3, and 
+In order to achieve synchronization, the MASTER device provides a clock and trigger over the SATA S1 connector that
+is then connected to the S2 of SLAVE 1 board. SLAVE1 then passes the clock forward to SLAVE 2, SLAVE2 to SLAVE 3, and
 so on (SLAVE N to SLAVE N+1). This way we can achieve synchronization of all boards in the system.
 
 Important notice: MASTER and SLAVE boards do use different OS-es!
@@ -60,11 +60,11 @@ Connecting together:
 
     #.  Connect all Red Pitayas to same network via ethernet cables (switch or router that is connected to Client PC).
 
-        Improtant notice: Make sure that you network can provide enough throughput for all the data you are about to 
-        stream. It is also recommnnede to use dedicated network only used only for X-channel system.
+        Important notice: Make sure that you network can provide enough throughput for all the data you are about to
+        stream. It is also recommended to use dedicated network only used only for X-channel system.
 
 
-    #.  Connect SATA cables betwen master and slave devices.
+    #.  Connect SATA cables between master and slave devices.
 
         MASTER SATA S1 -> SLAVE 1 SATA S2
 
@@ -80,11 +80,11 @@ Connecting together:
 .. figure:: img/Master_and_slaves_2.jpg
     :width: 80%
 
-***********************
-Download a X-channel streaming client to your computer
-***********************
+*******************************************************
+Download an X-channel streaming client to your computer
+*******************************************************
 
-1.) Connect to MASTER board by typing URL on sticker to WEB browser and open streamin app
+1.) Connect to MASTER board by typing URL on sticker to WEB browser and open streaming app
 
 .. figure:: img/run_app.png
     :width: 80%
@@ -107,17 +107,17 @@ In this example we will acquire data from all 3 RP units which gives as 6 RF inp
     MASTER IP=192.168.2.141, SLAVE1_IP=192.168.2.60 SLAVE2_IP=192.168.2.25
 
 
-1.  Open streaming app on MASTER ana all SLAVE boards view WEB interface
+1.  Open streaming app on MASTER and all SLAVE boards view WEB interface
 
-Notice: streamin app can be also started via ssh by running /opt/redpitaya/bin/streaming-server.run.sh on RP
+Notice: streaming app can be also started via ssh by running /opt/redpitaya/bin/streaming-server.run.sh on RP
 
-2.  Open streaming app on MASTER ana all SLAVE boards view WEB interface
+2.  Open streaming app on MASTER and all SLAVE boards view WEB interface
 
-3.  Set streaming paramters / confirguration
+3.  Set streaming parameters / configuration
 
 Configuration can be set over WEB interface UI which is then stored into /root/.streaming_config on RP.
 
-In this example we will show how to set configuration remotely using alredy prepared `test.conf <https://downloads.redpitaya.com/doc/streaming/test.conf>`__ 
+In this example we will show how to set configuration remotely using already prepared `test.conf <https://downloads.redpitaya.com/doc/streaming/test.conf>`__
 that will set all MASTERS and SLAVES to these settings.
 
 .. figure:: img/settings.png

--- a/developerGuide/hardware/122-16/top.rst
+++ b/developerGuide/hardware/122-16/top.rst
@@ -3,9 +3,9 @@
 SDRlab 122-16
 #############
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 

--- a/developerGuide/hardware/122-16_EXT/top.rst
+++ b/developerGuide/hardware/122-16_EXT/top.rst
@@ -12,9 +12,9 @@ ADC spec.
 .. figure:: ../125-14/Extension_connector.png
    :align: center
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 

--- a/developerGuide/hardware/125-10/top.rst
+++ b/developerGuide/hardware/125-10/top.rst
@@ -1,11 +1,11 @@
-.. _top_125_14:
+.. _top_125_10:
 
 STEMlab 125-10
-###########
+##############
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 

--- a/developerGuide/hardware/125-14-Z20/top.rst
+++ b/developerGuide/hardware/125-14-Z20/top.rst
@@ -8,9 +8,9 @@ STEMlab 125-14-Z7020-LN is a standard STEMlab 125-14 board that:
 
 * has populated additional linear analog power for analog power supplies to reduce RF inputs and outputs noise and consequently increase ENOB.To find out more about the performance of STEMlab 125-14 with DC analog power supplies, refer to Leonhard Neuhaus's blog `Red Pitaya DAC performance <https://ln1985blog.wordpress.com/2016/02/07/red-pitaya-dac-performance/>`_.
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 
@@ -18,7 +18,7 @@ Technical specifications
 Schematics
 **********
 
-* `User-DOC_STEMlab_125-14_V1.1_STEMlab 125-14 Z7020 LN.PDF <https://downloads.redpitaya.com/doc/User-DOC_STEMlab_125-14_V1.1%28STEMlab%20125-14%20Z7020%20LN%29.PDF>`_ 
+* `User-DOC_STEMlab_125-14_V1.1_STEMlab 125-14 Z7020 LN.PDF <https://downloads.redpitaya.com/doc/User-DOC_STEMlab_125-14_V1.1%28STEMlab%20125-14%20Z7020%20LN%29.PDF>`_
 
 .. note::
 

--- a/developerGuide/hardware/125-14/top.rst
+++ b/developerGuide/hardware/125-14/top.rst
@@ -5,9 +5,9 @@ STEMlab 125-14
 ##############
 
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 
@@ -33,7 +33,7 @@ Fast analog IO
 
 .. toctree::
    :maxdepth: 6
-   
+
    fastIO
 
 *********
@@ -42,7 +42,7 @@ Extension
 
 .. toctree::
    :maxdepth: 6
-   
+
    extent
 
 
@@ -82,19 +82,19 @@ ADC clock can be provided by:
     :alt: Logo
     :align: center
     :width:  400px
-    
+
 
 ************
 Certificates
 ************
 
-Besides the functional testing Red Pitaya passed the safety and electromagnetic compatibility (EMC) tests at an 
+Besides the functional testing Red Pitaya passed the safety and electromagnetic compatibility (EMC) tests at an
 external `testing and certification institute <http://www.siq.si/?L=3>`_.
 
 
 .. toctree::
    :maxdepth: 6
-   
+
    cets
 
 
@@ -103,7 +103,7 @@ Cooling options
 ***************
 
 For additional cooling we recommend a 30mm or 25mm fan. You can utilize the power connector on the board to power
-the fan, however please note that it supplies only 5 V. The power connector is located between micro-SD socket and 
+the fan, however please note that it supplies only 5 V. The power connector is located between micro-SD socket and
 the host USB connector.
 
 .. figure:: cooling-powerPin.jpg
@@ -113,14 +113,14 @@ the host USB connector.
     | Red Pitaya power connector.
     | Image via `blog <https://rroeng.blogspot.com/2014/03/keep-your-red-pitaya-cool.html>`_ (with permission from Jacek Radzikowski).
 
-    
+
 .. note::
- 
+
     Power connector is a standard 2-pin 0.1" connector.
     Supplies only 5V.
-    
+
 
 .. toctree::
    :maxdepth: 6
-   
+
    cooling

--- a/developerGuide/hardware/125-14_EXT/top.rst
+++ b/developerGuide/hardware/125-14_EXT/top.rst
@@ -13,9 +13,9 @@ ADC spec.
    :align: center
 
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 

--- a/developerGuide/hardware/125-14_LN/top.rst
+++ b/developerGuide/hardware/125-14_LN/top.rst
@@ -13,9 +13,9 @@ suggest you refer to Leonhard Neuhaus's blog.
 * `Red Pitaya DAC performance <https://ln1985blog.wordpress.com/2016/02/07/red-pitaya-dac-performance/>`_
 
 
-*********
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 

--- a/developerGuide/hardware/250-12/top.rst
+++ b/developerGuide/hardware/250-12/top.rst
@@ -1,10 +1,10 @@
 SIGNALlab 250-12
 ################
 
-   
-*********
+
+************************
 Technical specifications
-*********
+************************
 
 * :ref:`Product comparison table <rp-board-comp>`
 

--- a/developerGuide/hardware/platforms.rst
+++ b/developerGuide/hardware/platforms.rst
@@ -3,12 +3,11 @@ Red Pitaya platforms
 
 .. toctree::
    :maxdepth: 2
-   
-   125-10/vs.rst
+
    125-10/top.rst
    125-14/top.rst
    125-14_EXT/top.rst
-   125-14_LN/top.rst   
+   125-14_LN/top.rst
    125-14-Z20/top.rst
    125-14_MULTI/top.rst
    122-16/top.rst

--- a/developerGuide/software/build/fpga/fpga.rst
+++ b/developerGuide/software/build/fpga/fpga.rst
@@ -31,7 +31,7 @@ If the installer glitches out anyway, your /etc/os-release file needs to be chan
 First, backup the file and then open it as superuser with a text editor such as nano:
 
 .. code-block:: shell-session
-   
+
    $ sudo nano /etc/os-release
 
 and change the VERSION line to “VERSION=”18.04.4 LTS (Bionic Beaver)”” and save the file. The edited file should look something like this:
@@ -59,7 +59,7 @@ To build fpga requires a repository with a device tree from xilinx.
 You can prepare it by running the command:
 
 .. code-block:: shell-session
-   
+
    $ make -f Makefile.x86 devicetree
 
 .. note::
@@ -67,9 +67,9 @@ You can prepare it by running the command:
    You can upload the file manually:
 
    .. code-block:: shell-session
-   
+
       curl -L https://github.com/Xilinx/device-tree-xlnx/archive/xilinx-v2017.2.tar.gz/ -o device-tree-xlnx-xilinx-v2017.2.tar.gz
-   
+
    and extract the .tar.gz to /[redpitaya path]/tmp/device-tree-xlnx-xilinx-v2017.2
 
 *******************
@@ -136,7 +136,7 @@ It is reccommended to use 0.94 release as default project.
 |                   |    PS was used. This improves speed and reliability and reduces |br|   | Spectrum analyzer |br| |
 |                   |    RTL complexity.                                              |br|   | Bode analyzer |br|     |
 |                   | 2. A value increment bug in the generator was fixed, this should |br|  | LCR meter |br|         |
-|                   |    improve generated frequencies near half sampling rate.       |br|   |                        | 
+|                   |    improve generated frequencies near half sampling rate.       |br|   |                        |
 |                   | 3. XADC custom RTL wrapper was replaced with Xilinx AXI XADC.  |br|    |                        |
 |                   |    This enables the use of the Linux driver with IIO streaming |br|    |                        |
 |                   |    support.                                                            |                        |
@@ -210,10 +210,11 @@ Table of required build flags for FPGA projects per board
 | SIGNALlab 250-12     | MODEL=Z20_250       |
 +----------------------+---------------------+
 
-On the PC that has Vivado installed run the following commands to properly configure system variables (needs to be done every time you open a new terminal window). 
+On the PC that has Vivado installed run the following commands to properly configure system variables (needs to be done every time you open a new terminal window).
 Alternatively, you can add the following lines to your .bashrc file using a text editor – this will ensure that they are run at the system startup:
 
 .. code-block:: shell-session
+
    source <path to Xilinx installation directory>/Xilinx/Vivado/2020.1/settings64.sh
    source <path to Xilinx installation directory>/Xilinx/SDK/2019.1/settings64.sh
 
@@ -239,11 +240,11 @@ Create a new directory for the Red Pitaya code. Then download the code by runnin
 
    git clone https://github.com/RedPitaya/RedPitaya.git
 
-The devicetree sources must also be downloaded and extracted by running 
+The devicetree sources must also be downloaded and extracted by running
 
 .. code-block:: shell-session
 
-   make -f Makefile.x86 devicetree 
+   make -f Makefile.x86 devicetree
 
 The default mode for building the FPGA is to run a TCL script inside Vivado.
 Non project mode is used, to avoid the generation of project files,
@@ -290,18 +291,18 @@ If the script returns the following error:
 
    BD_TCL-109" "ERROR" "This script was generated using Vivado 2020.1 ....
 
-First, find the line containing 
+First, find the line containing
 
 .. code-block:: none
 
-   set scripts_vivado_version 2020.1 
+   set scripts_vivado_version 2020.1
 
 and change 2020.1 to your version.
-This is a quick and dirty way to get the build working in other versions of Vivado. 
+This is a quick and dirty way to get the build working in other versions of Vivado.
 However, this way could be problematic if some of the IPs used are different in your version.
 
 To update the script properly, open the project GUI(see below), go to menu Reports-> Report IP Status. A new tab opens below the code window.
-If all IPs are not up-to-date, they need to be updated. 
+If all IPs are not up-to-date, they need to be updated.
 Before doing this, the TCL script must still be manually modified to your Vivado version, or the block design will not be created when Vivado starts.
 
 .. figure:: IPupdate.png
@@ -331,17 +332,17 @@ For example, v0.94 project for STEMlab 125-14:
 
 .. figure:: project_make.png
 
-A new, blank project will automatically built and all the necessary files associated with Red Pitaya will be added. 
+A new, blank project will automatically built and all the necessary files associated with Red Pitaya will be added.
 You can add/write your Verilog module at the end of red_pitaya_top.sv file (or add a new source by right clicking the Design Sources folder and Add Source):
 
 .. figure:: vivado_project.png
 
-You can connect newly added sources in the Diagram (Block Design) section (If it is not open: Window => Design => double click system). 
-Add them to the design by right click => Add Module in the design window (for more information check the Learn FPGA programming => FPGA lessons section) 
+You can connect newly added sources in the Diagram (Block Design) section (If it is not open: Window => Design => double click system).
+Add them to the design by right click => Add Module in the design window (for more information check the Learn FPGA programming => FPGA lessons section)
 https://redpitaya-knowledge-base.readthedocs.io/en/latest/learn_fpga/4_lessons/top.html
 
-Before you try to Run Synthesis, Run Implementation or Write Bitstream, you should check Language and Region settings on your Ubuntu computer – 
-make sure you have a Format that uses a dot (“.”) as a decimal separator (United Kingdom or United States will work). 
+Before you try to Run Synthesis, Run Implementation or Write Bitstream, you should check Language and Region settings on your Ubuntu computer –
+make sure you have a Format that uses a dot (“.”) as a decimal separator (United Kingdom or United States will work).
 Otherwise the Synthesis might fail as some parts of Vivado demand a dot as the decimal separator, which will cause Vivado not to recognize certain parts of the model.
 
 The resulting .bit file is located in fpga/prj/<project name>/project/redpitaya.runs/impl_1/red_pitaya_top.bit
@@ -359,38 +360,40 @@ The resulting .bit file is located in <Red Pitaya repository>/RedPitaya/fpga/prj
 Programming via JTAG
 ********************
 
-These instructions show how to use a JTAG cable to program a Red Pitaya directly from Xilinx Vivado. 
+These instructions show how to use a JTAG cable to program a Red Pitaya directly from Xilinx Vivado.
 To do so we use Red Pitaya STEMlab 125-14, Ubuntu 20.04, Vivado 2020.1, Digilent JTAG-HS3 cable with a 14 to 6 pin adapter and Digilent Adept 2 software.
 
 To start, get an appropriate JTAG cable. In these instructions, we use a Digilent JTAG-HS3 cable with a 14 to 6 pin adapter.
 Digilent JTAG-HS2 may be used as well and might be more appropriate, as it uses a 6 pin connector that can connect directly to Red Pitaya's JTAG.
-For a complete list of JTAG cables, supported by Vivado, see Xilinx UG908 - Programming and Debugging, appendix D. 
+For a complete list of JTAG cables, supported by Vivado, see Xilinx UG908 - Programming and Debugging, appendix D.
 https://www.xilinx.com/content/dam/xilinx/support/documentation/sw_manuals/xilinx2021_2/ug908-vivado-programming-debugging.pdf
 
 See if the JTAG cable is detected. In Ubuntu, that is done with:
 
 .. code-block:: shell-session
+
     $ lsusb
 
 JTAG-HS3 is displayed as a FTDI device.
 
 .. figure:: lsusb.jpg
 
-Now, install Digilent Adept 2 software from https://digilent.com/reference/software/adept/start. 
+Now, install Digilent Adept 2 software from https://digilent.com/reference/software/adept/start.
 You will need both Utilities and Runtime. These are both available as .deb packages. If installing from GUI does not work, they can be installed using:
 
 .. code-block:: shell-session
+
     $ sudo dpkg -i <path to package>
 
 Once these packages are installed, you can check if the driver detects your adapter (only applies to Digilent cables):
 
 .. code-block:: shell-session
-    $ djtgcfg enum
 
+    $ djtgcfg enum
 
 .. figure:: driver_check.jpg
 
-Now, open Vivado 2020.1, click Program and Debug -> Open Target -> Auto Connect. 
+Now, open Vivado 2020.1, click Program and Debug -> Open Target -> Auto Connect.
 
 .. figure:: program_menu.jpg
 
@@ -402,11 +405,11 @@ Now plug your cable onto Red Pitaya's JTAG connector. The pins are marked on the
 
 .. figure:: JTAG_pins.jpg
 
-A Xilinx device should now appear in Vivado (on the detected cable). In this case, it's a xc7z010_1. 
+A Xilinx device should now appear in Vivado (on the detected cable). In this case, it's a xc7z010_1.
 
 .. figure:: program.jpg
 
-Now, you can click Program Device. 
+Now, you can click Program Device.
 
 .. figure:: connected.jpg
 
@@ -451,8 +454,8 @@ which will prepare an organized waveform window.
 
    $ make top_tb WAV=1
 
-   
-.. _devicetree:   
+
+.. _devicetree:
 
 ***********
 Device tree
@@ -542,7 +545,7 @@ General purpose inputs
              ----------  |  ----------
    Vin  0----| 30.0kΩ |-----| 4.99kΩ |----0  GND
              ----------     ----------
-   
+
 .. math::
 
    ratio = \frac{4.99 k\Omega}{30.0 k\Omega + 4.99  k\Omega} = 0.143

--- a/developerGuide/software/build/fpga/jtag_manual.rst
+++ b/developerGuide/software/build/fpga/jtag_manual.rst
@@ -1,35 +1,37 @@
-These instructions show how to use a JTAG cable to program a Red Pitaya directly from Xilinx Vivado. 
+These instructions show how to use a JTAG cable to program a Red Pitaya directly from Xilinx Vivado.
 To do so we use Red Pitaya STEMlab 125-14, Ubuntu 20.04, Vivado 2020.1, Digilent JTAG-HS3 cable with a 14 to 6 pin adapter and Digilent Adept 2 software.
 
 To start, get an appropriate JTAG cable. In these instructions, we use a Digilent JTAG-HS3 cable with a 14 to 6 pin adapter.
 Digilent JTAG-HS2 may be used as well and might be more appropriate, as it uses a 6 pin connector that can connect directly to Red Pitaya's JTAG.
-For a complete list of JTAG cables, supported by Vivado, see Xilinx UG908 - Programming and Debugging, appendix D. 
+For a complete list of JTAG cables, supported by Vivado, see Xilinx UG908 - Programming and Debugging, appendix D.
 https://www.xilinx.com/content/dam/xilinx/support/documentation/sw_manuals/xilinx2021_2/ug908-vivado-programming-debugging.pdf
 
 See if the JTAG cable is detected. In Ubuntu, that is done with:
 
 .. code-block:: shell-session
+
     $ lsusb
 
 JTAG-HS3 is displayed as a FTDI device.
 
 .. figure:: lsusb.jpg
 
-Now, install Digilent Adept 2 software from https://digilent.com/reference/software/adept/start. 
+Now, install Digilent Adept 2 software from https://digilent.com/reference/software/adept/start.
 You will need both Utilities and Runtime. These are both available as .deb packages. If installing from GUI does not work, they can be installed using:
 
 .. code-block:: shell-session
+
     $ sudo dpkg -i <path to package>
 
 Once these packages are installed, you can check if the driver detects your adapter (only applies to Digilent cables):
 
 .. code-block:: shell-session
-    $ djtgcfg enum
 
+    $ djtgcfg enum
 
 .. figure:: driver_check.jpg
 
-Now, open Vivado 2020.1, click Program and Debug -> Open Target -> Auto Connect. 
+Now, open Vivado 2020.1, click Program and Debug -> Open Target -> Auto Connect.
 
 .. figure:: program_menu.jpg
 
@@ -41,15 +43,14 @@ Now plug your cable onto Red Pitaya's JTAG connector. The pins are marked on the
 
 .. figure:: JTAG_pins.jpg
 
-A Xilinx device should now appear in Vivado (on the detected cable). In this case, it's a xc7z010_1. 
+A Xilinx device should now appear in Vivado (on the detected cable). In this case, it's a xc7z010_1.
 
 .. figure:: program.jpg
 
-Now, you can click Program Device. 
+Now, you can click Program Device.
 
 .. figure:: connected.jpg
 
 A bitfile selector prompt appears and when a valid file is selected, Red Pitaya can be programmed.
 
 .. figure:: file_select.jpg
-


### PR DESCRIPTION
Fix some of the sphinx-build warnings.

Fix some spelling errors.

Remove extraneous whitespace and add missing newlines at end of file.