### PR TITLE
Update acqRF-exm1.rst - Add a channel argument to fix a compile error

### DIFF
--- a/appsFeatures/examples/acqRF-exm1.rst
+++ b/appsFeatures/examples/acqRF-exm1.rst
@@ -350,7 +350,7 @@ Code - C
     
             rp_AcqReset();
             rp_AcqSetDecimation(RP_DEC_8);
-            rp_AcqSetTriggerLevel(0.1); //Trig level is set in Volts while in SCPI 
+            rp_AcqSetTriggerLevel(RP_CH_1, 0.1); //Trig level is set in Volts while in SCPI 
             rp_AcqSetTriggerDelay(0);
 
             // there is an option to select coupling when using SIGNALlab 250-12 


### PR DESCRIPTION
Added a channel argument to rp_AcqSetTriggerLevel.
This fixes a compile error, and brings the code into line with https://github.com/RedPitaya/RedPitaya/tree/master/Examples/C