### PR TITLE
Update dig-exm1.rst Python example

### DIFF
--- a/appsFeatures/examples/dig-exm1.rst
+++ b/appsFeatures/examples/dig-exm1.rst
@@ -120,9 +120,9 @@ Code - Python
     rp_s = scpi.scpi(sys.argv[1])
 
     if (len(sys.argv) > 2):
-    led = int(sys.argv[2])
+        led = int(sys.argv[2])
     else:
-    led = 0
+        led = 0
 
     print ("Blinking LED["+str(led)+"]")
 


### PR DESCRIPTION
Incorrect indenting on python blink example meant code did not run. This has been tested and rectified.