### PR TITLE
Fix dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 **Minor updates:**
 
 - Fixed and updated Gen 1 specifications.
-- Updated and clarifier E3 add-on board instructions.
+- Updated and clarified E3 add-on board instructions.
 - Updated Gen 2 booting instructions.
 
 **Links affected:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 **Links affected:**
 
 - Added redirects for broken links from *April 2025 - Update 1*.
+- Fixed Sphinx dependency issues with the documentation build process.
 - None.
 
 ## April 2025 - Update 1

--- a/conf.py
+++ b/conf.py
@@ -46,9 +46,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_tabs.tabs',
     'notfound.extension',
-    'github'
-    
-#    'myst_parser',
+    'github',
+    'myst_parser'
 #    'xref'
 ]
 


### PR DESCRIPTION
## April 2025 - Update 2

**Major updates:**

- 404 page added to reroute old broken links.
- Gen 2 fast analog inputs and output measurements added.
- Gen 2 heatmap images added.
- Updated certification page with new certificates and downloadable PDFs.

**Minor updates:**

- Fixed and updated Gen 1 specifications.
- Updated and clarified E3 add-on board instructions.
- Updated Gen 2 booting instructions.

**Links affected:**

- Added redirects for broken links from *April 2025 - Update 1*.
- Fixed Sphinx dependency issues with the documentation build process.
- None.